### PR TITLE
Fixed issue #3 (RuntimeError: the bucket being iterated changed size)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Fixing "RuntimeError: the bucket being iterated changed size" (issue #3)
+  [gogobd]
+  
 - Depend on ``Products.CMFPlone`` instead of ``Plone`` to not fetch unnecessary dependencies.
   [thet]
 

--- a/src/plone/app/multilingualindexes/languagefallback.py
+++ b/src/plone/app/multilingualindexes/languagefallback.py
@@ -96,11 +96,11 @@ class LanguageFallbackIndex(UnIndex):
             # Document language changed or new doc
             if old_obj_langs != set():
                 # Document is not new. Need to remove all fallbacks
-                for old_lang in old_obj_langs:
+                for old_lang in list(old_obj_langs):
                     self.removeForwardIndexEntry(old_lang, documentId)
                     res = 1
                     try:
-                        for old_lang in old_obj_langs:
+                        for old_lang in list(old_obj_langs):
                             self._unindex[documentId].remove(old_lang)
                         if not len(self._unindex[documentId]):
                             del self._unindex[documentId]


### PR DESCRIPTION
Just using lists for iterations instead of blank BTrees objects fixed the issue.