### PR TITLE
Format by isort

### DIFF
--- a/src/plone/app/multilingualindexes/languagefallback.py
+++ b/src/plone/app/multilingualindexes/languagefallback.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from Acquisition import aq_base
 from AccessControl.class_init import InitializeClass
+from Acquisition import aq_base
 from App.special_dtml import DTMLFile
 from BTrees.OOBTree import OOTreeSet
 from logging import getLogger


### PR DESCRIPTION
Format codes by applying isort.

**Why?**

Recently introduced codes are not formatted.
This repository is used by the integration tests for https://github.com/PyCQA/isort and expected to be correctly formatted.